### PR TITLE
Fix debian includes

### DIFF
--- a/Findhdhomerun.cmake
+++ b/Findhdhomerun.cmake
@@ -4,8 +4,8 @@ if(PKG_CONFIG_FOUND)
 endif()
 
 if(NOT HDHOMERUN_FOUND)
-  find_path(HDHOMERUN_INCLUDE_DIRS hdhomerun/hdhomerun.h
-            PATH_SUFFIXES hdhomerun)
+  find_path(HDHOMERUN_INCLUDE_DIRS hdhomerun.h
+            PATH_SUFFIXES hdhomerun libhdhomerun)
   find_library(HDHOMERUN_LIBRARIES hdhomerun)
 endif()
 

--- a/debian/control
+++ b/debian/control
@@ -2,8 +2,8 @@ Source: kodi-pvr-hdhomerun
 Priority: extra
 Maintainer: Nobody <nobody@kodi.tv>
 Build-Depends: debhelper (>= 9.0.0), cmake, kodi-pvr-dev,
-               libkodiplatform-dev (>= 16.0.0), kodi-addon-dev
-Standards-Version: 3.9.2
+               libkodiplatform-dev (>= 16.0.0), kodi-addon-dev, libhdhomerun-dev (>= 20150826), libjsoncpp-dev
+Standards-Version: 3.9.5
 Section: libs
 
 Package: kodi-pvr-hdhomerun

--- a/src/HDHomeRunTuners.h
+++ b/src/HDHomeRunTuners.h
@@ -25,7 +25,7 @@
 
 #include "client.h"
 #include <platform/threads/mutex.h>
-#include <hdhomerun/hdhomerun.h>
+#include <hdhomerun.h>
 #include <json/json.h>
 
 class HDHomeRunTuners


### PR DESCRIPTION
this fixes packaging on debian based systems. Note that you need libhdhomerun2 from the ubuntu 16.04 development branch.

It also still compiles with the kodi intree addon build system on linux. Didn't runtime test though.

Once you are happy with your addon, please consider submitting to https://github.com/xbmc/repo-binary-addons for inclusion in kodi.